### PR TITLE
Add support for PsySH v0.9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
   },
   "require": {
     "php": "7.1 - 7.3",
-    "psy/psysh": "0.8.17 - 0.9",
+    "psy/psysh": "^0.8.17|^0.9.1",
     "symfony/config": "^4.0",
     "symfony/dependency-injection": "^4.0",
     "symfony/http-kernel": "^4.0"


### PR DESCRIPTION
This PR adds support for PsySH v0.9. I skipped v0.9.0 because there was a bugfix release an hour later.